### PR TITLE
Calculate total speed from all interfaces in the connection list from ix-f export

### DIFF
--- a/peeringdb_server/models.py
+++ b/peeringdb_server/models.py
@@ -1645,8 +1645,7 @@ class IXLan(pdb_models.IXLanBase):
 
                                     speed = 0
                                     for iface in connection.get("if_list", []):
-                                        if iface.get("if_speed", 0) > speed:
-                                            speed = iface["if_speed"]
+                                        speed += iface.get("if_speed", 0)
 
                                     for lan in connection.get("vlan_list", []):
                                         ipv4_valid = False


### PR DESCRIPTION
When the if_list contains more than one entry, add them together instead of choosing
the largest value.

This causes connection speeds for Internet Exchanges reporting LAGs as a list of member interfaces to be reported correctly.