### PR TITLE
in.whoisd: ignore empty queries

### DIFF
--- a/config/facsimile/tmpl/_ALL_/_DEPLOY_/peeringdb/in.whoisd
+++ b/config/facsimile/tmpl/_ALL_/_DEPLOY_/peeringdb/in.whoisd
@@ -14,8 +14,9 @@ try:
     from django.core.management import execute_from_command_line
 
     inp = sys.stdin.readline().strip()
-    argv = ['in.whoisd', 'pdb_whois', inp]
-    execute_from_command_line(argv)
+    if inp:
+        argv = ['in.whoisd', 'pdb_whois', inp]
+        execute_from_command_line(argv)
 
 except BaseException as e:
     # TODO log here - need to inherit


### PR DESCRIPTION
This is to prevent django.log from being filled with:

Unknown query type ''
Unknown query type ''
Unknown query type ''
Unknown query type ''
[...]

due to repeated load balancer health checks.