### PR TITLE
Disabled Telugu, Danish, Indonesian and enabled Greek and Spanish.

### DIFF
--- a/config/facsimile/peeringdb.yaml
+++ b/config/facsimile/peeringdb.yaml
@@ -45,13 +45,12 @@ locale:
   - pt
   - it
   - cs_CZ
-  - da_DK
   - de_DE
+  - el_GR
+  - es_ES
   - fr_FR
-  - id_ID
   - ja_JP
   - ru_RU
-  - te_IN
   - zh_CN
 
 

--- a/config/facsimile/tmpl/_ALL_/_DEPLOY_/peeringdb/peeringdb_com/settings.d/10-locale.conf
+++ b/config/facsimile/tmpl/_ALL_/_DEPLOY_/peeringdb/peeringdb_com/settings.d/10-locale.conf
@@ -12,18 +12,20 @@ LOCALE_PATHS = (
     '',
     os.path.join(PROJECT_PATH, 'locale/'),
 )
+#{% if 'da_DK' in env.locale %}('da-dk', _('Danish')),{% endif %}
+#{% if 'id_ID' in env.locale %}('id-id', _('Indonesian')),{% endif %}
+#{% if 'te_IN' in env.locale %}('te-en', _('Telugu')),{% endif %}
 LANGUAGES = [
 {% if 'en' in env.locale %}('en', _('English')),{% endif %}
 {% if 'pt' in env.locale %}('pt', _('Portuguese')),{% endif %}
 {% if 'it' in env.locale %}('it', _('Italian')),{% endif %}
 {% if 'cs_CZ' in env.locale %}('cs-cz', _('Czech')),{% endif %}
-{% if 'da_DK' in env.locale %}('da-dk', _('Danish')),{% endif %}
 {% if 'de_DE' in env.locale %}('de-de', _('German')),{% endif %}
+{% if 'el_GR' in env.locale %}('el-gr', _('Greek')),{% endif %}
+{% if 'es_ES' in env.locale %}('es-es', _('Spanish')),{% endif %}
 {% if 'fr_FR' in env.locale %}('fr-fr', _('French')),{% endif %}
-{% if 'id_ID' in env.locale %}('id-id', _('Indonesian')),{% endif %}
 {% if 'ja_JP' in env.locale %}('ja-jp', _('Japanese')),{% endif %}
 {% if 'ru_RU' in env.locale %}('ru-ru', _('Russian')),{% endif %}
-{% if 'te_IN' in env.locale %}('te-en', _('Telugu')),{% endif %}
 {% if 'zh_CN' in env.locale %}('zh-cn', _('Chinese')),{% endif %}
 ]
 # Language code for this installation. All choices can be found here:


### PR DESCRIPTION
Per Filiz, Product Committee does not want a language enabled unless it is 80% translated per https://translate.peeringdb.com/projects/peeringdb/#languages , so removed those below the threshold and added those above.