### PR TITLE
Make URLs in Admin GUI clickable (#161), turns out this is actually t…

### DIFF
--- a/config/facsimile/peeringdb.yaml
+++ b/config/facsimile/peeringdb.yaml
@@ -167,6 +167,7 @@ install:
     - $SRC_DIR$/peeringdb_server/templates/admin/user-organizations.html
     - $SRC_DIR$/peeringdb_server/templates/site/request-ownership.html
     - $SRC_DIR$/peeringdb_server/templates/admin/org_merge_tool.html
+    - $SRC_DIR$/peeringdb_server/templates/admin/change_form.html
     - $SRC_DIR$/peeringdb_server/templates/admin/peeringdb_server/commandlinetool/change_list.html
     - $SRC_DIR$/peeringdb_server/templates/admin/peeringdb_server/commandlinetool/preview_command.html
     - $SRC_DIR$/peeringdb_server/templates/admin/peeringdb_server/commandlinetool/prepare_command.html

--- a/peeringdb_server/templates/admin/change_form.html
+++ b/peeringdb_server/templates/admin/change_form.html
@@ -1,0 +1,3 @@
+{% extends "admin/change_form.html" %}
+{% block js_remove_url %}
+{% endblock %}


### PR DESCRIPTION
…he default behaviour of django, but django-grappelli implements a hack to get rid of it - this change removes that hack from the template