### PR TITLE
Allow http, https, telnet and ssh for Route Server URLs

### DIFF
--- a/peeringdb_server/serializers.py
+++ b/peeringdb_server/serializers.py
@@ -279,7 +279,8 @@ class FieldMethodValidator(object):
 class ExtendedURLField(serializers.URLField):
     def __init__(self, **kwargs):
         super(ExtendedURLField, self).__init__(**kwargs)
-        validator = URLValidator(message=self.error_messages["invalid"])
+        validator = URLValidator(schemes=("http", "https", "telnet", "ssh"),
+                                 message=self.error_messages["invalid"])
         self.validators = []
         self.validators.append(validator)
 


### PR DESCRIPTION
This fixes https://github.com/peeringdb/peeringdb/issues/462

related: https://github.com/peeringdb/django-peeringdb/pull/34