### PR TITLE
Tie CSRF token to session Id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache/
 .coverage
 .facsimile
+*.DS_STORE
 *.env
 *.log
 *.py[cod]

--- a/mainsite/settings/__init__.py
+++ b/mainsite/settings/__init__.py
@@ -1135,4 +1135,6 @@ if TUTORIAL_MODE:
 else:
     EMAIL_SUBJECT_PREFIX = f"[{RELEASE_ENV}] "
 
+CSRF_USE_SESSIONS = True
+
 print_debug(f"loaded settings for PeeringDB {PEERINGDB_VERSION} (DEBUG: {DEBUG})")

--- a/peeringdb_server/static/peeringdb.js
+++ b/peeringdb_server/static/peeringdb.js
@@ -33,8 +33,7 @@ PeeringDB = {
     twentyc.listutil.filter_input.init();
     twentyc.listutil.sortable.init();
 
-    this.csrf = Cookies.get("csrftoken")
-
+    this.csrf = document.querySelector('[name=csrfmiddlewaretoken]').value;
     $.ajaxSetup({
       beforeSend : function(xhr, settings) {
         if(!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type) && !this.crossDomain) {


### PR DESCRIPTION
The CSRF tokens are currently not tied to a session that opens the door for the old tokens created to be used as they are still dangling around when the session is closed. Also, it exposes the risk of cross account usability of CSRF token. 

Here are more details about that flags in Django:

https://docs.djangoproject.com/en/4.0/ref/settings/#std-setting-CSRF_USE_SESSIONS 