### PR TITLE
Prevent browser caching of the OAuth application detail page

### DIFF
--- a/peeringdb_server/views.py
+++ b/peeringdb_server/views.py
@@ -46,9 +46,9 @@ from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
 from django.views import View
+from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
-from django.views.decorators.cache import never_cache
 from django_grainy.util import Permissions
 from django_otp.plugins.otp_email.models import EmailDevice
 from django_security_keys.ext.two_factor.views import (  # noqa
@@ -633,10 +633,7 @@ oauth2_views.ApplicationRegistration = ApplicationRegistration
 class ApplicationDetail(ApplicationOwnerMixin, oauth2_views.ApplicationDetail):
     @never_cache
     def get(self, request, *args, **kwargs):
-        return super(
-            ApplicationDetail, self
-        ).get(request, *args, **kwargs)
-
+        return super(ApplicationDetail, self).get(request, *args, **kwargs)
 
 
 oauth2_views.ApplicationDetail = ApplicationDetail

--- a/peeringdb_server/views.py
+++ b/peeringdb_server/views.py
@@ -48,6 +48,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views import View
 from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
+from django.views.decorators.cache import never_cache
 from django_grainy.util import Permissions
 from django_otp.plugins.otp_email.models import EmailDevice
 from django_security_keys.ext.two_factor.views import (  # noqa
@@ -630,7 +631,12 @@ oauth2_views.ApplicationRegistration = ApplicationRegistration
 
 
 class ApplicationDetail(ApplicationOwnerMixin, oauth2_views.ApplicationDetail):
-    pass
+    @never_cache
+    def get(self, request, *args, **kwargs):
+        return super(
+            oauth2_views.ApplicationDetail, self
+        ).get(request, *args, **kwargs)
+
 
 
 oauth2_views.ApplicationDetail = ApplicationDetail

--- a/peeringdb_server/views.py
+++ b/peeringdb_server/views.py
@@ -634,7 +634,7 @@ class ApplicationDetail(ApplicationOwnerMixin, oauth2_views.ApplicationDetail):
     @never_cache
     def get(self, request, *args, **kwargs):
         return super(
-            oauth2_views.ApplicationDetail, self
+            ApplicationDetail, self
         ).get(request, *args, **kwargs)
 
 

--- a/tests/test_oauth2_views.py
+++ b/tests/test_oauth2_views.py
@@ -99,6 +99,15 @@ def test_app_list(oauth2_apps):
 def test_app_detail(oauth2_apps):
     override_app_model()
 
+    def check_cache_headers(resp):
+        assert resp.has_header("Cache-Control")
+        cache_control_header = resp.headers.get("Cache-Control")
+        assert "max-age=0" in cache_control_header
+        assert "no-cache" in cache_control_header
+        assert "no-store" in cache_control_header
+        assert "must-revalidate" in cache_control_header
+        assert "private" in cache_control_header
+
     user_app, org_app, other_app = oauth2_apps
     user = user_app.user
 
@@ -112,6 +121,7 @@ def test_app_detail(oauth2_apps):
     resp = client.get(url)
 
     assert resp.status_code == 200
+    check_cache_headers(resp)
 
     # detail org owned app
 
@@ -120,6 +130,7 @@ def test_app_detail(oauth2_apps):
 
     assert resp.status_code == 200
     assert f"{org_app.org.name}'s management" in resp.content.decode("utf-8")
+    check_cache_headers(resp)
 
     # detail unprovisioned org owned app (prohibited)
 


### PR DESCRIPTION
* added CacheControl headers to the ApplicationDetail page that prevent caching