### PR TITLE
User Profile: Sort language select input with user's locale

### DIFF
--- a/mainsite/settings/__init__.py
+++ b/mainsite/settings/__init__.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import django.conf.global_settings
+import django.conf.locale
 import structlog
 
 from mainsite.oauth2.scopes import SupportedScopes
@@ -1084,6 +1085,19 @@ if ENABLE_ALL_LANGUAGES:
                 language_dict[code] = name
 
     LANGUAGES = sorted(language_dict.items())
+
+EXTRA_LANG_INFO = {
+    "oc": {
+        "bidi": False,
+        "code": "oc",
+        "name": "Occitan",
+        "name_local": "occitan",
+    },
+}
+
+# Add custom languages not provided by Django
+LANG_INFO = dict(django.conf.locale.LANG_INFO, **EXTRA_LANG_INFO)
+django.conf.locale.LANG_INFO = LANG_INFO
 
 
 # dynamic config starts here

--- a/peeringdb_server/data_views.py
+++ b/peeringdb_server/data_views.py
@@ -250,7 +250,11 @@ def organizations(request):
 def languages(request):
     from django.conf import settings
 
-    translation.get_language()
-    return JsonResponse(
-        {"locales": [{"id": id, "name": _(name)} for (id, name) in settings.LANGUAGES]}
-    )
+    locales = []
+    for (id, name) in settings.LANGUAGES:
+        li = translation.get_language_info(id)
+        locales.append(
+            {"id": id, "name": f"{li['name_translated']} ({li['name_local']})"}
+        )
+
+    return JsonResponse({"locales": locales})

--- a/peeringdb_server/static/20c/twentyc.edit.js
+++ b/peeringdb_server/static/20c/twentyc.edit.js
@@ -1094,7 +1094,6 @@ twentyc.editable.input.register(
     },
 
     load : function(data) {
-      var k, v;
       this.element.empty();
       if(this.source.data("edit-data-all-entry")) {
         var allEntry = this.source.data("edit-data-all-entry").split(":")
@@ -1102,10 +1101,14 @@ twentyc.editable.input.register(
       } else {
         var allEntry = null;
       }
-      for(k in data) {
-        v = data[k];
+      var values = Object.values(data);
+      if(this.source.data("edit-sorted") == "yes") {
+        values.sort(
+          (a, b) => a.name.localeCompare(b.name));
+      }
+      for(var v of values) {
         if(allEntry && allEntry[0] == v.id)
-          continue
+          continue;
         this.add_opt(v.id, v.name);
       }
       this.element.trigger("change");

--- a/peeringdb_server/templates/site/profile-pick-language.html
+++ b/peeringdb_server/templates/site/profile-pick-language.html
@@ -14,6 +14,7 @@
         <div class="col-xs-12 col-sm-12 col-md-12"
              data-edit-type="select"
              data-edit-data="locales"
+             data-edit-sorted="yes"
              data-edit-required="no"
              data-edit-name="locale"
              data-edit-value="{{ LANGUAGE_CODE }}"


### PR DESCRIPTION
Allows any select input to use a new `data-edit-sorted` attribute to indicate that the select options should be sorted by name, as represented in the user's currently-selected locale.

Updates the language selection drop-down in the User Profile settings to use this new attribute.