### PR TITLE
fix to the timestamps being followed by the letter Z

### DIFF
--- a/peeringdb_server/export_views.py
+++ b/peeringdb_server/export_views.py
@@ -30,7 +30,7 @@ def export_ixf_ix_members(ixlans, pretty=False):
 
     rv = {
         "version": "0.6",
-        "timestamp": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "timestamp": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
         "member_list": member_list,
         "ixp_list": [{"ixp_id": ixp.id, "shortname": ixp.name} for ixp in ixp_list],
     }

--- a/peeringdb_server/templates/site/beta_banner.html
+++ b/peeringdb_server/templates/site/beta_banner.html
@@ -9,7 +9,7 @@ This is a beta/testing instance of PeeringDB. Some features may work differently
 {% endblocktrans %}
 {% if SHOW_AUTO_PROD_SYNC_WARNING %}
 {% blocktrans trimmed with beta_sync_dt|date:"Y-m-d H:i:s" as dt %}
-- all data will be refreshed from production at {{ dt }}Z
+- all data will be refreshed from production at {{ dt }}
 {% endblocktrans %}
 {% else %}
 - automatically scheduled refreshes from production are currently disabled.


### PR DESCRIPTION
May have found the issue regarding the timestamp showing the letter "Z" after them. 
Couldn't find any other mention of it anywhere in the server code.