### PR TITLE
docs: fix typo in docs/dev/translation.md

### DIFF
--- a/docs/dev/translation.md
+++ b/docs/dev/translation.md
@@ -40,7 +40,7 @@ Uncomment the mount point for `locale` under `volumes`
 
 ```
 
-Create an empty .venv to avoid errors when bringing containers up:
+Create an empty .env to avoid errors when bringing containers up:
 
 ```sh
 touch Ctl/dev/.env


### PR DESCRIPTION
Fixing typo in docs/dev/translation.md from PR  #1400.

Thanks.