### PR TITLE
Accept "-" (dash) in social_media fields

### DIFF
--- a/peeringdb_server/validators.py
+++ b/peeringdb_server/validators.py
@@ -434,7 +434,7 @@ def validate_social_media(value):
                     )
             elif service in ["instagram", "twitter", "tiktok", "facebook", "linkedin"]:
                 # validate username
-                regex = r"^(?=.{4,32}$)(?![.-])(?!.*[.]{2})[a-zA-Z0-9._]+(?<![.])$"
+                regex = r"^(?=.{4,32}$)(?![.-])(?!.*[.]{2})[a-zA-Z0-9._-]+(?<![.-])$"
                 matches = re.search(regex, identifier)
                 if not matches:
                     raise ValidationError(


### PR DESCRIPTION
#1382, #1434 - Permit "-" in social_media fields.

By not permitting this we prevent users from registering legitimate company URI's (e.g. LinkedIn) for their Networks in PeeringDB.