### PR TITLE
Template: Update typo in geocode string ('not be')

### DIFF
--- a/peeringdb_server/templates/site/view.html
+++ b/peeringdb_server/templates/site/view.html
@@ -369,12 +369,12 @@
                 <a href="https://maps.google.com/?q={{ row.value.latitude|stringformat:"f" }},{{ row.value.longitude|stringformat:"f" }}">{{ row.value.latitude }}, {{ row.value.longitude }}</a>
               </span>
               <div id="geocode_inactive" class="note inactive hidden">
-                {% trans "Geocode data for this entity could not obtained at this point. This is done automatically upon address field changes."%}
+                {% trans "Geocode data for this entity could not be obtained at this point. This is done automatically upon address field changes."%}
               </div>
             {% else %}
             <span id="geocode_active"></span>
             <div id="geocode_inactive" class="note inactive">
-              {% trans "Geocode data for this entity could not obtained at this point. This is done automatically upon address field changes."%}
+              {% trans "Geocode data for this entity could not be obtained at this point. This is done automatically upon address field changes."%}
             </div>
             {% endif %}
           </div>


### PR DESCRIPTION
Correct typo - PEERINGDB-202309AMLNQ1

FROM:
Geocode data for this entity could not obtained at this point

TO:
Geocode data for this entity could not **be** obtained at this point