### PR TITLE
Validator: Add validator for X usernames, were requirements

### DIFF
--- a/peeringdb_server/validators.py
+++ b/peeringdb_server/validators.py
@@ -438,9 +438,10 @@ def validate_social_media(value):
                     )
             elif service in ["instagram", "x", "tiktok", "facebook", "linkedin"]:
                 # validate username
-                regex = (
-                    r"^(-*)(?=.{4,32}$)(?![.\-])(?!.*[.]{2})[a-zA-Z0-9._\-]+(?<![.])$"
-                )
+                if service in ["x"]:
+                    regex = r"^[a-zA-Z0-9_]{1,15}$"
+                else:
+                    regex = r"^(-*)(?=.{4,32}$)(?![.\-])(?!.*[.]{2})[a-zA-Z0-9._\-]+(?<![.])$"
 
                 matches = re.search(regex, identifier)
                 if not matches:


### PR DESCRIPTION
are different for the generalized regex match.

> A username can only contain alphanumeric characters (letters A-Z, numbers 0-9) with the
> exception of underscores, as noted above. Check to make sure your desired username
> does not contain any symbols, dashes, or spaces.

https://help.twitter.com/en/managing-your-account/x-username-rules

Add a specific if-else regex match for X usernames to take into account that PeeringDB users are able to have X usernames of less than 4 characters that are the current minimum our generalized username regexer checks in the string length match. I.e. We currently accept 4-32. X allows 1-15 in length.