### PR TITLE
Implement: Search results and sponsorships badges #1802

### DIFF
--- a/src/peeringdb_server/templates/site/search_result.html
+++ b/src/peeringdb_server/templates/site/search_result.html
@@ -283,9 +283,6 @@
       {% for row in search_ixp %}
       <div class="result_row">
         <a href="/{{'InternetExchange'|ref_tag}}/{{row.id}}">{{row.name}}</a>
-        {% if row.sponsorship %}
-        <a href="/sponsors" class="sponsor {{ row.sponsorship.css }}">{{ row.sponsorship.label }} {% trans "sponsor" %}</a>
-        {% endif %}
         {% if row.sub_name %}<div class="highlight">{{ row.sub_name }}</div>{% endif %}
       </div>
       {% endfor %}
@@ -296,9 +293,6 @@
       {% for row in search_net%}
       <div class="result_row">
         <a href="/{{'Network'|ref_tag}}/{{row.id}}">{{row.name}}{% if search_version == 2 %} ({{ row.extra.asn }}){% endif %}</a>
-        {% if row.sponsorship %}
-        <a href="/sponsors" class="sponsor {{ row.sponsorship.css }}">{{ row.sponsorship.label }} {% trans "sponsor" %}</a>
-        {% endif %}
         {% if row.sub_name %}<div class="highlight">{{ row.sub_name }}</div>{% endif %}
       </div>
       {% endfor %}
@@ -310,9 +304,6 @@
       {% for row in search_fac %}
       <div class="result_row">
         <a href="/{{'Facility'|ref_tag}}/{{row.id}}">{{row.name}}</a>{% if row.campus %}<span class="icon muted"><a href="/campus/{{ row.campus }}"><img src="{% static "campus.svg" %}"></a></span>{% endif %}
-        {% if row.sponsorship %}
-        <a href="/sponsors" class="sponsor {{ row.sponsorship.css }}">{{ row.sponsorship.label }} {% trans "sponsor" %}</a>
-        {% endif %}
         {% if row.sub_name %}<div class="highlight">{{ row.sub_name }}</div>{% endif %}
       </div>
       {% endfor %}

--- a/src/peeringdb_server/templates/site_next/search_result.html
+++ b/src/peeringdb_server/templates/site_next/search_result.html
@@ -283,9 +283,6 @@
       {% for row in search_ixp %}
       <div class="result_row">
         <a href="/{{'InternetExchange'|ref_tag}}/{{row.id}}">{{row.name}}</a>
-        {% if row.sponsorship %}
-        <a href="/sponsors" class="sponsor {{ row.sponsorship.css }}">{{ row.sponsorship.label }} {% trans "sponsor" %}</a>
-        {% endif %}
         {% if row.sub_name %}<div class="highlight">{{ row.sub_name }}</div>{% endif %}
       </div>
       {% endfor %}
@@ -296,9 +293,6 @@
       {% for row in search_net%}
       <div class="result_row">
         <a href="/{{'Network'|ref_tag}}/{{row.id}}">{{row.name}}{% if search_version == 2 %} ({{ row.extra.asn }}){% endif %}</a>
-        {% if row.sponsorship %}
-        <a href="/sponsors" class="sponsor {{ row.sponsorship.css }}">{{ row.sponsorship.label }} {% trans "sponsor" %}</a>
-        {% endif %}
         {% if row.sub_name %}<div class="highlight">{{ row.sub_name }}</div>{% endif %}
       </div>
       {% endfor %}
@@ -310,9 +304,6 @@
       {% for row in search_fac %}
       <div class="result_row">
         <a href="/{{'Facility'|ref_tag}}/{{row.id}}">{{row.name}}</a>{% if row.campus %}<span class="icon muted"><a href="/campus/{{ row.campus }}"><img src="{% static "campus.svg" %}"></a></span>{% endif %}
-        {% if row.sponsorship %}
-        <a href="/sponsors" class="sponsor {{ row.sponsorship.css }}">{{ row.sponsorship.label }} {% trans "sponsor" %}</a>
-        {% endif %}
         {% if row.sub_name %}<div class="highlight">{{ row.sub_name }}</div>{% endif %}
       </div>
       {% endfor %}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -134,7 +134,7 @@ class SearchTests(TestCase):
             .split('id="search-list-view"')[0],
         )
 
-        assert len(m) == 4
+        assert len(m) == 1
 
     def test_search_case(self):
         """


### PR DESCRIPTION
"On search results only: The sponsorship badge should only be visible on "Organization" listing entries. (Object pages remain unchanged.)"