### PR TITLE
Security: JSON Deserialization of Untrusted Data in admin tool command processing

### DIFF
--- a/src/peeringdb_server/management/commands/pdb_process_admin_tool_command.py
+++ b/src/peeringdb_server/management/commands/pdb_process_admin_tool_command.py
@@ -31,6 +31,19 @@ class Command(BaseCommand):
             try:
                 tool = get_tool_from_data({"tool": command.tool})
                 arguments = json.loads(command.arguments)
+
+                # Validate JSON structure and types
+                if not isinstance(arguments, dict):
+                    raise ValueError("Arguments must be a JSON object")
+                if "kwargs" not in arguments:
+                    raise ValueError("Missing required key 'kwargs'")
+                if "args" not in arguments:
+                    raise ValueError("Missing required key 'args'")
+                if not isinstance(arguments.get("kwargs"), dict):
+                    raise ValueError("'kwargs' must be a JSON object")
+                if not isinstance(arguments.get("args"), list):
+                    raise ValueError("'args' must be a JSON array")
+
                 tool.kwargs = arguments.get("kwargs")
                 tool.args = arguments.get("args")
                 tool._run(command, commit=True)


### PR DESCRIPTION
## Summary

Security: JSON Deserialization of Untrusted Data in admin tool command processing

## Problem

**Severity**: `High` | **File**: `src/peeringdb_server/management/commands/pdb_process_admin_tool_command.py:L38`

The pdb_process_admin_tool_command command deserializes JSON arguments from the database (CommandLineTool.arguments) without validation. If an attacker can write to the command queue, they could inject malicious JSON.

## Solution

Add validation of the JSON structure and argument types before passing to the tool. Validate that expected keys exist and contain expected types.

## Changes

- `src/peeringdb_server/management/commands/pdb_process_admin_tool_command.py` (modified)