### PR TITLE
Fix api count query

### DIFF
--- a/src/peeringdb_server/rest.py
+++ b/src/peeringdb_server/rest.py
@@ -756,8 +756,8 @@ class ModelViewSet(viewsets.ModelViewSet):
                 if row_count > enforced_limit:
                     qset = qset[:enforced_limit]
                     self.request.meta_response["truncated"] = (
-                    f"Your search query (with depth {depth}) returned more than {enforced_limit} rows and has been truncated. Please be more specific in your filters, use the limit and skip parameters to page through the resultset or drop the depth parameter"
-                )
+                        f"Your search query (with depth {depth}) returned more than {enforced_limit} rows and has been truncated. Please be more specific in your filters, use the limit and skip parameters to page through the resultset or drop the depth parameter"
+                    )
 
         if depth > 0 or self.kwargs:
             return self.serializer_class.prefetch_related(

--- a/src/peeringdb_server/rest.py
+++ b/src/peeringdb_server/rest.py
@@ -751,10 +751,11 @@ class ModelViewSet(viewsets.ModelViewSet):
             # we are handling a list request and need to apply the limit and skip
             # parameters if they are present
 
-            row_count = qset.count()
-            if enforced_limit and depth > 0 and row_count > enforced_limit:
-                qset = qset[:enforced_limit]
-                self.request.meta_response["truncated"] = (
+            if enforced_limit and depth > 0:
+                row_count = qset.count()
+                if row_count > enforced_limit:
+                    qset = qset[:enforced_limit]
+                    self.request.meta_response["truncated"] = (
                     f"Your search query (with depth {depth}) returned more than {enforced_limit} rows and has been truncated. Please be more specific in your filters, use the limit and skip parameters to page through the resultset or drop the depth parameter"
                 )
 


### PR DESCRIPTION
I found what I think is a significant performance issue: COUNT(*) was being done even for "depth=0", which the conditional immediately after doesn't need and was therefore being thrown away.

Hopefully that'll reduce a lot of processing done for sync clients that exercise this path.