### PR TITLE
User api key scoping

### DIFF
--- a/src/peeringdb_server/api_key_views.py
+++ b/src/peeringdb_server/api_key_views.py
@@ -9,13 +9,190 @@ from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_protect
 from grainy.const import PERM_READ
 
-from peeringdb_server.forms import OrgAdminUserPermissionForm, OrganizationAPIKeyForm
+from peeringdb_server.forms import (
+    OrgAdminUserPermissionForm,
+    OrganizationAPIKeyForm,
+    UserAPIKeyPermissionForm,
+)
 from peeringdb_server.models import (
+    Carrier,
+    Facility,
+    InternetExchange,
+    Network,
+    Organization,
     OrganizationAPIKey,
     OrganizationAPIPermission,
     UserAPIKey,
+    UserAPIPermission,
 )
 from peeringdb_server.org_admin_views import load_entity_permissions, org_admin_required
+from peeringdb_server.permissions import check_permissions
+
+# reftag -> model, for resolving user-key scoping ids ("net.5", "ix.3", ...)
+# to an actual object. Deliberately excludes "org" (org.<id> is a whole
+# organization and handled separately below) since org is not a HandleRef
+# model in the same registry.
+USER_KEY_REF_TAG_MODELS = {
+    "net": Network,
+    "ix": InternetExchange,
+    "fac": Facility,
+    "carrier": Carrier,
+}
+
+# reverse of the above, keyed by the grainy namespace segment name each
+# model registers under (see the `@grainy_model(namespace=...)` decorators
+# in models.py) rather than the shorter ref_tag, since that's what shows
+# up in a saved namespace string.
+NAMESPACE_SEGMENT_TO_REF_TAG = {
+    "network": "net",
+    "internetexchange": "ix",
+    "facility": "fac",
+    "carrier": "carrier",
+}
+
+
+def resolve_user_key_permission_id(user, permission_id):
+    """
+    Resolve a user-key scoping id ("org.<id>" or "<reftag>.<id>") to
+    a grainy namespace, after confirming `user` already has read
+    access to that namespace on their own account.
+
+    Scoping can only ever narrow what a key can see - it is never a
+    grant - so if the user themselves can't read the target object,
+    there is nothing valid to scope the key to and this fails.
+
+    Returns a (namespace, error) tuple - exactly one of which will
+    be None.
+
+    Note: unlike organization API key scoping, this does not support
+    bare type-level ids ("net" meaning "any network"), since without
+    an owning org to anchor it that would mean "every network in the
+    entire database" rather than "every network belonging to this
+    org" - a materially different and much broader grant. Only
+    single objects or whole organizations can be targeted.
+    """
+
+    try:
+        reftag, raw_id = permission_id.split(".", 1)
+        obj_id = int(raw_id)
+    except (ValueError, AttributeError):
+        return None, _("Invalid permission id")
+
+    if reftag == "org":
+        try:
+            obj = Organization.objects.get(id=obj_id)
+        except Organization.DoesNotExist:
+            return None, _("Organization not found")
+    elif reftag in USER_KEY_REF_TAG_MODELS:
+        model = USER_KEY_REF_TAG_MODELS[reftag]
+        try:
+            obj = model.objects.get(id=obj_id)
+        except model.DoesNotExist:
+            return None, _("Object not found")
+    else:
+        return None, _("Unsupported permission id")
+
+    namespace = obj.grainy_namespace
+
+    if not check_permissions(user, namespace, PERM_READ, explicit=False):
+        return None, _("You do not have access to this object")
+
+    return namespace, None
+
+
+def save_user_key_permissions(user, key, entity_ids):
+    """
+    Replace the scoping on a UserAPIKey.
+
+    `entity_ids` is a list of permissioning ids (e.g. ["net.5",
+    "org.3"]). Each is resolved and validated via
+    `resolve_user_key_permission_id` before being saved - invalid or
+    inaccessible ids are collected and returned as errors rather than
+    silently dropped, so the caller can surface them.
+
+    User key scoping is always read-only: this is a "read scoped API
+    key" feature, not a mechanism for granting write access, so the
+    permission level is hardcoded to PERM_READ regardless of what
+    the user might otherwise be able to do to the target object.
+
+    Returns (namespaces_saved, errors).
+    """
+
+    namespaces = []
+    errors = {}
+
+    for entity_id in entity_ids:
+        namespace, error = resolve_user_key_permission_id(user, entity_id)
+        if error:
+            errors[entity_id] = error
+        else:
+            namespaces.append(namespace)
+
+    if errors:
+        return [], errors
+
+    # full replace - wipe any existing scoping and re-apply
+    key.grainy_permissions.all().delete()
+
+    for namespace in namespaces:
+        UserAPIPermission.objects.create(
+            namespace=namespace, permission=PERM_READ, api_key=key
+        )
+
+    return namespaces, {}
+
+
+def load_user_key_permissions(key):
+    """
+    Return a dict of {permission_id: permission_level} for a
+    UserAPIKey's current scoping, in the same "<reftag>.<id>" /
+    "org.<id>" id format `save_user_key_permissions` accepts - the
+    inverse operation, for populating the account settings UI.
+
+    Namespaces that don't cleanly map back to a known object type are
+    skipped rather than raised, since they shouldn't occur through
+    normal use of this feature but a stale/manually-inserted row
+    shouldn't break the whole listing.
+    """
+
+    perms = {}
+
+    for perm in key.grainy_permissions.all():
+        parts = perm.namespace.split(".")
+
+        # "peeringdb.organization.<id>" - whole org
+        if len(parts) == 3 and parts[:2] == ["peeringdb", "organization"]:
+            perms[f"org.{parts[2]}"] = perm.permission
+            continue
+
+        # "peeringdb.organization.<org_id>.<segment>.<id>" - single object
+        if len(parts) >= 5 and parts[:2] == ["peeringdb", "organization"]:
+            segment, obj_id = parts[3], parts[4]
+            reftag = NAMESPACE_SEGMENT_TO_REF_TAG.get(segment)
+            if reftag:
+                perms[f"{reftag}.{obj_id}"] = perm.permission
+
+    return perms
+
+
+def load_all_user_key_permissions(user):
+    """
+    Returns a dict of all of `user`'s non-revoked API keys with
+    their current scoping, keyed by prefix - the per-user analogue
+    of `load_all_key_permissions(org)`, used to populate the account
+    settings page without one AJAX round trip per key.
+    """
+
+    rv = {}
+    for key in user.api_keys.filter(revoked=False):
+        rv[key.prefix] = {
+            "prefix": key.prefix,
+            "name": key.name,
+            "is_readonly": key.readonly,
+            "is_scoped": key.is_scoped,
+            "perms": load_user_key_permissions(key),
+        }
+    return rv
 
 
 def save_key_permissions(org, key, perms):
@@ -345,5 +522,122 @@ def remove_user_key(request, **kwargs):
     return JsonResponse(
         {
             "status": "ok",
+        }
+    )
+
+
+@login_required
+def user_key_permissions(request, **kwargs):
+    """
+    Returns the current scoping for one of the requesting user's own
+    API keys.
+
+    Only ever operates on keys owned by request.user - there is no
+    org-admin equivalent here since these are personal keys.
+    """
+
+    prefix = request.GET.get("prefix")
+
+    try:
+        key = UserAPIKey.objects.get(user=request.user, prefix=prefix)
+    except UserAPIKey.DoesNotExist:
+        return JsonResponse({"non_field_errors": [_("Key not found")]}, status=404)
+
+    return JsonResponse(
+        {
+            "status": "ok",
+            "is_scoped": key.is_scoped,
+            "permissions": load_user_key_permissions(key),
+        }
+    )
+
+
+@login_required
+@csrf_protect
+@transaction.atomic
+def user_key_permission_update(request, **kwargs):
+    """
+    Add a scoping entry to one of the requesting user's own API keys.
+
+    entity = permission id (e.g. "net.5", "org.3")
+
+    Scoping is additive from the caller's perspective (add this one
+    entity to the key's scope) but implemented as a full replace
+    under the hood via `save_user_key_permissions`, since a key's
+    scope has to be recomputed as a whole to stay consistent - the
+    existing entries are read back out with `load_user_key_permissions`
+    first so this call doesn't clobber them.
+    """
+
+    prefix = request.POST.get("key_prefix")
+
+    try:
+        key = UserAPIKey.objects.get(user=request.user, prefix=prefix)
+    except UserAPIKey.DoesNotExist:
+        return JsonResponse({"non_field_errors": [_("Key not found")]}, status=404)
+
+    form = UserAPIKeyPermissionForm(request.POST)
+    if not form.is_valid():
+        return JsonResponse(form.errors, status=400)
+
+    entity = form.cleaned_data.get("entity")
+    entity_ids = list(load_user_key_permissions(key).keys())
+    if entity not in entity_ids:
+        entity_ids.append(entity)
+
+    namespaces, errors = save_user_key_permissions(request.user, key, entity_ids)
+
+    if errors:
+        return JsonResponse({"non_field_errors": list(errors.values())}, status=400)
+
+    return JsonResponse(
+        {
+            "status": "ok",
+            "is_scoped": key.is_scoped,
+            "permissions": load_user_key_permissions(key),
+        }
+    )
+
+
+@login_required
+@csrf_protect
+@transaction.atomic
+def user_key_permission_remove(request, **kwargs):
+    """
+    Remove a scoping entry from one of the requesting user's own API
+    keys.
+
+    entity = permission id
+
+    Removing the last remaining scoping entry restores the key to
+    its unscoped state (full inherited user permissions, or
+    read-only-everything if `readonly` is also set) - it does not
+    leave the key able to see nothing, since an empty
+    `grainy_permissions` set is exactly what `return_user_api_key_perms`
+    treats as "not scoped".
+    """
+
+    prefix = request.POST.get("key_prefix")
+    entity = request.POST.get("entity")
+
+    try:
+        key = UserAPIKey.objects.get(user=request.user, prefix=prefix)
+    except UserAPIKey.DoesNotExist:
+        return JsonResponse({"non_field_errors": [_("Key not found")]}, status=404)
+
+    entity_ids = list(load_user_key_permissions(key).keys())
+    if entity in entity_ids:
+        entity_ids.remove(entity)
+        namespaces, errors = save_user_key_permissions(request.user, key, entity_ids)
+        if errors:
+            return JsonResponse(
+                {"non_field_errors": list(errors.values())}, status=400
+            )
+
+    return JsonResponse(
+        {
+            "status": "ok",
+            "is_scoped": key.is_scoped,
+            "permissions": load_user_key_permissions(key),
         }
     )

--- a/src/peeringdb_server/forms.py
+++ b/src/peeringdb_server/forms.py
@@ -35,6 +35,26 @@ class OrganizationAPIKeyForm(forms.Form):
     org_id = forms.IntegerField()
 
 
+class UserAPIKeyPermissionForm(forms.Form):
+    """
+    Validates a single scoping entry submitted for a UserAPIKey.
+
+    `entity` follows the same permissioning id format used for
+    organization API keys - "org.<id>" for a whole organization, or
+    "<reftag>.<id>" (net.5, ix.3, fac.7, carrier.2) for a single
+    object. Resolution of the id to an actual grainy namespace (and
+    the check that the requesting user is allowed to see that
+    object) happens in `api_key_views.resolve_user_key_permission_id`,
+    since it requires a database lookup this form isn't set up to do.
+
+    Scoped user keys are read-only by design - this form doesn't
+    accept a permission level at all, it only accepts the identifier
+    of what the key is being scoped to.
+    """
+
+    entity = forms.CharField()
+
+
 class OrgAdminUserPermissionForm(forms.Form):
     entity = forms.CharField()
     perms = forms.IntegerField()

--- a/src/peeringdb_server/migrations/0154_user_api_permission.py
+++ b/src/peeringdb_server/migrations/0154_user_api_permission.py
@@ -1,0 +1,52 @@
+# Generated for scoped UserAPIKey permissions
+
+import django.db.models.deletion
+import django_grainy.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "peeringdb_server",
+            "0153_alter_ixfmemberdata_speed_alter_networkixlan_speed_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="UserAPIPermission",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "namespace",
+                    models.CharField(
+                        help_text="Permission namespace (A '.' delimited list of keys",
+                        max_length=255,
+                    ),
+                ),
+                ("permission", django_grainy.fields.PermissionField(default=1)),
+                (
+                    "api_key",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="grainy_permissions",
+                        to="peeringdb_server.userapikey",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "User API key Permission",
+                "verbose_name_plural": "User API key Permission",
+                "base_manager_name": "objects",
+            },
+        ),
+    ]

--- a/src/peeringdb_server/models.py
+++ b/src/peeringdb_server/models.py
@@ -6951,10 +6951,40 @@ class UserAPIKey(AbstractAPIKey, StripFieldMixin):
 
     status = models.CharField(max_length=16, choices=API_KEY_STATUS, default="active")
 
+    @property
+    def is_scoped(self):
+        """
+        Returns True if this key has explicit grainy permission
+        scoping applied (as opposed to inheriting the full user
+        permission set).
+        """
+        return self.grainy_permissions.exists()
+
     class Meta(AbstractAPIKey.Meta):
         verbose_name = "User API key"
         verbose_name_plural = "User API keys"
         db_table = "peeringdb_user_api_key"
+
+
+class UserAPIPermission(Permission, StripFieldMixin):
+    """
+    Describes a scoped permission for a UserAPIKey.
+
+    Mirrors OrganizationAPIPermission. Presence of any rows here
+    restricts (never expands) the permission set the key would
+    otherwise inherit from its owning user - see
+    `permissions.return_user_api_key_perms`.
+    """
+
+    class Meta:
+        verbose_name = _("User API key Permission")
+        verbose_name_plural = _("User API key Permission")
+        base_manager_name = "objects"
+
+    api_key = models.ForeignKey(
+        UserAPIKey, related_name="grainy_permissions", on_delete=models.CASCADE
+    )
+    objects = PermissionManager()
 
 
 def password_reset_token():

--- a/src/peeringdb_server/permissions.py
+++ b/src/peeringdb_server/permissions.py
@@ -221,7 +221,7 @@ def return_user_api_key_perms(key):
             user_permissions=permissions,
             scope=key.grainy_permissions.permission_set(),
         )
-
+        permissions.grant_all = False	
     return permissions
 
 
@@ -262,7 +262,7 @@ def intersect_permission_sets(user_permissions, scope):
             grainy_constant.PERM_UPDATE,
             grainy_constant.PERM_DELETE,
         ):
-            if requested_level & flag and user_permissions.pset.check(
+            if requested_level & flag and user_permissions.check(
                 ns, flag, explicit=False
             ):
                 effective_level |= flag

--- a/src/peeringdb_server/permissions.py
+++ b/src/peeringdb_server/permissions.py
@@ -199,6 +199,13 @@ def return_user_api_key_perms(key):
 
     If the UserAPIKey is marked readonly, it downgrades
     all permissions to readonly.
+
+    If the UserAPIKey has explicit grainy permission scoping
+    (`key.grainy_permissions`), the resulting permission set is
+    further restricted to the intersection of the user's actual
+    permissions and the key's declared scope - a scoped key can
+    never see more than the user could see without it, regardless
+    of what namespace/level is set on the key itself.
     """
     user = key.user
     permissions = Permissions(user)
@@ -209,7 +216,61 @@ def return_user_api_key_perms(key):
         }
         permissions.pset.update(readonly_perms)
 
+    if key.grainy_permissions.exists():
+        permissions.pset = intersect_permission_sets(
+            user_permissions=permissions,
+            scope=key.grainy_permissions.permission_set(),
+        )
+
     return permissions
+
+
+def intersect_permission_sets(user_permissions, scope):
+    """
+    Given a `Permissions` instance holding a user's real permission
+    set and a `PermissionSet` describing a requested scope (e.g. from
+    a scoped UserAPIKey), returns a new PermissionSet containing only
+    the namespaces named in `scope`, each capped at the level the
+    user actually holds there.
+
+    This is a restriction, never a grant: a namespace/level present
+    in `scope` but not actually held by the user (or held at a lower
+    level) contributes nothing, or contributes at the lower level.
+
+    Note this checks `user_permissions.pset.check(...)` directly
+    rather than going through `Permissions.check()` - the latter
+    short-circuits to True for superusers via `grant_all`, which
+    would silently defeat scoping on a superuser's key. Operating on
+    the raw pset means a scoped key is bound by its declared scope
+    even when the owning user is a superuser.
+    """
+    from grainy.core import PermissionSet
+
+    restricted = PermissionSet()
+
+    for ns in scope.namespaces:
+        requested_level = scope.get_permissions(ns)
+
+        # Check bit-by-bit (rather than a single `get_permissions` call)
+        # so we also honor permissions the user holds on a *parent*
+        # namespace - e.g. user has CRUD on `org.1.network`, key scope
+        # names `org.1.network.5.poc_set.private` explicitly.
+        effective_level = 0
+        for flag in (
+            grainy_constant.PERM_READ,
+            grainy_constant.PERM_CREATE,
+            grainy_constant.PERM_UPDATE,
+            grainy_constant.PERM_DELETE,
+        ):
+            if requested_level & flag and user_permissions.pset.check(
+                ns, flag, explicit=False
+            ):
+                effective_level |= flag
+
+        if effective_level:
+            restricted[ns] = effective_level
+
+    return restricted
 
 
 def return_org_api_key_perms(key):

--- a/src/peeringdb_server/static/peeringdb.js
+++ b/src/peeringdb_server/static/peeringdb.js
@@ -1853,6 +1853,53 @@ twentyc.editable.module.register(
 );
 
 /**
+ * editable user api key scoping endpoint
+ */
+
+twentyc.editable.module.register(
+  "user_key_perm_listing",
+  {
+    loading_shim : true,
+
+    init : function() {
+      this.listing_init();
+    },
+
+    key_prefix : function() {
+      return this.container.data("edit-key-prefix");
+    },
+
+    // user key scoping has no read/write level to toggle - a scoped
+    // entry is always read-only - so unlike `key_perm_listing` this
+    // only ever needs to merge in the key_prefix before submitting.
+    prepare_data : function(extra) {
+      this.target.data.key_prefix = this.key_prefix();
+      if(extra)
+        $.extend(this.target.data, extra);
+    },
+
+    execute_add : function(trigger, container) {
+      this.components.add.editable("export", this.target.data);
+      var data = this.target.data;
+      this.prepare_data();
+      this.target.execute("update", this.components.add, function(response) {
+        this.listing_add(data.entity, trigger, container, data);
+      }.bind(this));
+    },
+
+    execute_remove : function(trigger, container) {
+      var row = this.row(trigger);
+      this.prepare_data({entity: row.data("edit-id")});
+      this.target.execute("remove", trigger, function(response) {
+        this.listing_execute_remove(trigger, container);
+      }.bind(this));
+    }
+
+  },
+  "listing"
+);
+
+/**
  * editable uoar management endpoint
  */
 

--- a/src/peeringdb_server/static/peeringdb_ui_next.js
+++ b/src/peeringdb_server/static/peeringdb_ui_next.js
@@ -1834,6 +1834,53 @@ PeeringDB = {
   );
 
   /**
+   * editable user api key scoping endpoint
+   */
+
+  twentyc.editable.module.register(
+    "user_key_perm_listing",
+    {
+      loading_shim : true,
+
+      init : function() {
+        this.listing_init();
+      },
+
+      key_prefix : function() {
+        return this.container.data("edit-key-prefix");
+      },
+
+      // user key scoping has no read/write level to toggle - a scoped
+      // entry is always read-only - so unlike `key_perm_listing` this
+      // only ever needs to merge in the key_prefix before submitting.
+      prepare_data : function(extra) {
+        this.target.data.key_prefix = this.key_prefix();
+        if(extra)
+          $.extend(this.target.data, extra);
+      },
+
+      execute_add : function(trigger, container) {
+        this.components.add.editable("export", this.target.data);
+        var data = this.target.data;
+        this.prepare_data();
+        this.target.execute("update", this.components.add, function(response) {
+          this.listing_add(data.entity, trigger, container, data);
+        }.bind(this));
+      },
+
+      execute_remove : function(trigger, container) {
+        var row = this.row(trigger);
+        this.prepare_data({entity: row.data("edit-id")});
+        this.target.execute("remove", trigger, function(response) {
+          this.listing_execute_remove(trigger, container);
+        }.bind(this));
+      }
+
+    },
+    "listing"
+  );
+
+  /**
    * editable uoar management endpoint
    */
 

--- a/src/peeringdb_server/templates/site/profile-api-keys.html
+++ b/src/peeringdb_server/templates/site/profile-api-keys.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load util %}
 <div class="panel api-keys">
     <h3><a name="api-keys">{% trans "API Keys" %}</a></h3>
 
@@ -37,6 +38,51 @@
       <a class="btn btn-default" data-edit-action="revoke">{% trans "Revoke" %}</a>
     </div>
   </div>
+
+  {% with kperms=key_perms|get_item:key.prefix %}
+  <div class="row marg-top item"
+       data-edit-module="user_key_perm_listing"
+       data-edit-template="user-key-scope-item"
+       data-edit-key-prefix="{{ key.prefix }}"
+       data-edit-target="/user_keys/permissions">
+    <div class="col-12 col-sm-11 col-md-11 offset-md-1">
+      <div class="alert alert-info marg-top" style="font-size: 0.9em;">
+        {% blocktrans trimmed %}
+        Optionally scope this key to specific objects (e.g. "net.5" for a
+        single network, "org.3" for a whole organization). A scoped key
+        can only read the objects listed here, regardless of what you
+        would otherwise have access to - and is always read-only.
+        Leave empty for the key to keep its normal (unscoped)
+        permissions.
+        {% endblocktrans %}
+      </div>
+
+      <div data-edit-component="list" data-edit-template="user-key-scope-item">
+        {% for entity, level in kperms.perms.items %}
+        <div class="row marg-top item"
+             data-edit-id="{{ entity }}"
+             data-edit-label="{{ entity }}">
+          <div class="col-8 col-sm-9 col-md-9">{{ entity }}</div>
+          <div class="col-4 col-sm-3 col-md-3 right">
+            <a class="btn-row-delete" data-edit-action="remove">&times;</a>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+
+      <div class="row marg-top editable" data-edit-component="add">
+        <div class="col-8 col-sm-9 col-md-9">
+          <div data-edit-type="string" data-edit-name="entity"
+               data-edit-placeholder="net.5, org.3, ix.12, fac.4, carrier.1"></div>
+        </div>
+        <div class="col-4 col-sm-3 col-md-3 right">
+          <a class="btn btn-default" data-edit-action="add">{% trans "Scope" %}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endwith %}
+
   {% endif %}
   {% endfor %}
   </div>
@@ -82,5 +128,13 @@
     </div>
   </div>
 
+  <!-- KEY SCOPE ROW -->
+
+  <div id="user-key-scope-item" class="row item">
+    <div class="col-8 col-sm-9 col-md-9" data-edit-name="entity"></div>
+    <div class="col-4 col-sm-3 col-md-3 right">
+      <a class="btn-row-delete" data-edit-action="remove">&times;</a>
+    </div>
+  </div>
 
 </div>

--- a/src/peeringdb_server/templates/site_next/profile-api-keys.html
+++ b/src/peeringdb_server/templates/site_next/profile-api-keys.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load util %}
 <div class="panel api-keys">
     <h3><a name="api-keys">{% trans "API Keys" %}</a></h3>
 
@@ -37,6 +38,51 @@
       <a class="btn btn-default" data-edit-action="revoke">{% trans "Revoke" %}</a>
     </div>
   </div>
+
+  {% with kperms=key_perms|get_item:key.prefix %}
+  <div class="row marg-top item"
+       data-edit-module="user_key_perm_listing"
+       data-edit-template="user-key-scope-item"
+       data-edit-key-prefix="{{ key.prefix }}"
+       data-edit-target="/user_keys/permissions">
+    <div class="col-12 col-sm-11 col-md-11 offset-md-1">
+      <div class="alert alert-info marg-top" style="font-size: 0.9em;">
+        {% blocktrans trimmed %}
+        Optionally scope this key to specific objects (e.g. "net.5" for a
+        single network, "org.3" for a whole organization). A scoped key
+        can only read the objects listed here, regardless of what you
+        would otherwise have access to - and is always read-only.
+        Leave empty for the key to keep its normal (unscoped)
+        permissions.
+        {% endblocktrans %}
+      </div>
+
+      <div data-edit-component="list" data-edit-template="user-key-scope-item">
+        {% for entity, level in kperms.perms.items %}
+        <div class="row marg-top item"
+             data-edit-id="{{ entity }}"
+             data-edit-label="{{ entity }}">
+          <div class="col-8 col-sm-9 col-md-9">{{ entity }}</div>
+          <div class="col-4 col-sm-3 col-md-3 right">
+            <a class="btn-row-delete" data-edit-action="remove">&times;</a>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+
+      <div class="row marg-top editable" data-edit-component="add">
+        <div class="col-8 col-sm-9 col-md-9">
+          <div data-edit-type="string" data-edit-name="entity"
+               data-edit-placeholder="net.5, org.3, ix.12, fac.4, carrier.1"></div>
+        </div>
+        <div class="col-4 col-sm-3 col-md-3 right">
+          <a class="btn btn-default" data-edit-action="add">{% trans "Scope" %}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endwith %}
+
   {% endif %}
   {% endfor %}
   </div>
@@ -82,5 +128,13 @@
     </div>
   </div>
 
+  <!-- KEY SCOPE ROW -->
+
+  <div id="user-key-scope-item" class="row item">
+    <div class="col-8 col-sm-9 col-md-9" data-edit-name="entity"></div>
+    <div class="col-4 col-sm-3 col-md-3 right">
+      <a class="btn-row-delete" data-edit-action="remove">&times;</a>
+    </div>
+  </div>
 
 </div>

--- a/src/peeringdb_server/templatetags/util.py
+++ b/src/peeringdb_server/templatetags/util.py
@@ -145,6 +145,20 @@ def is_dict(value):
 
 
 @register.filter
+def get_item(mapping, key):
+    """
+    Dict lookup by a variable key, since the `dict.key` template
+    syntax only supports literal keys. Returns an empty dict rather
+    than None/KeyError when nothing matches, so callers can chain
+    `|get_item:x` straight into `.perms.items` without an extra
+    `{% if %}`.
+    """
+    if not mapping:
+        return {}
+    return mapping.get(key, {})
+
+
+@register.filter
 def is_bool(value):
     return isinstance(value, bool)
 

--- a/src/peeringdb_server/urls.py
+++ b/src/peeringdb_server/urls.py
@@ -232,6 +232,18 @@ urlpatterns = [
     re_path(r"^user_keys/add$", peeringdb_server.api_key_views.add_user_key),
     re_path(r"^user_keys/revoke$", peeringdb_server.api_key_views.remove_user_key),
     re_path(
+        r"^user_keys/permissions$",
+        peeringdb_server.api_key_views.user_key_permissions,
+    ),
+    re_path(
+        r"^user_keys/permissions/update$",
+        peeringdb_server.api_key_views.user_key_permission_update,
+    ),
+    re_path(
+        r"^user_keys/permissions/remove$",
+        peeringdb_server.api_key_views.user_key_permission_remove,
+    ),
+    re_path(
         r"^security_keys/request_registration$",
         security_keys_views.request_registration,
         name="security-keys-request-registration",

--- a/src/peeringdb_server/views.py
+++ b/src/peeringdb_server/views.py
@@ -87,7 +87,10 @@ from oauth2_provider.oauth2_backends import get_oauthlib_core
 
 import peeringdb_server.geo
 from peeringdb_server import settings
-from peeringdb_server.api_key_views import load_all_key_permissions
+from peeringdb_server.api_key_views import (
+    load_all_key_permissions,
+    load_all_user_key_permissions,
+)
 from peeringdb_server.data_views import BOOL_CHOICE, BOOL_CHOICE_WITH_OPT_OUT
 from peeringdb_server.deskpro import ticket_queue_rdap_error
 from peeringdb_server.forms import (
@@ -972,7 +975,11 @@ def view_verify(request):
     template = get_template(request, "site/verify.html")
     env = BASE_ENV.copy()
     env.update(
-        {"affiliations": request.user.organizations, "global_stats": global_stats()}
+        {
+            "affiliations": request.user.organizations,
+            "global_stats": global_stats(),
+            "key_perms": load_all_user_key_permissions(request.user),
+        }
     )
     return HttpResponse(template.render(env, request))
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,10 +1,14 @@
 import pytest
-from django.test import RequestFactory
+from django.test import Client, RequestFactory
 from django.urls import reverse
 from django_grainy.models import UserPermission
 from grainy.const import PERM_CRUD, PERM_READ
 from rest_framework.test import APIClient
 
+from peeringdb_server.api_key_views import (
+    resolve_user_key_permission_id,
+    save_user_key_permissions,
+)
 from peeringdb_server.models import (
     Carrier,
     Facility,
@@ -16,6 +20,7 @@ from peeringdb_server.models import (
     OrganizationAPIPermission,
     User,
     UserAPIKey,
+    UserAPIPermission,
 )
 from peeringdb_server.permissions import (
     check_permissions,
@@ -617,3 +622,243 @@ def test_get_exchange_w_org_key(org, exchange, groups):
     ix_from_api = response.json()["data"][0]
     assert ix_from_api["name"] == exchange.name
     assert ix_from_api["org_id"] == exchange.org.id
+
+
+"""
+USER API KEY SCOPING (read-scoped keys)
+"""
+
+
+@pytest.mark.django_db
+def test_user_api_permission_model(user):
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=user)
+    UserAPIPermission.objects.create(
+        api_key=api_key,
+        namespace="peeringdb.organization.1.network.1",
+        permission=PERM_READ,
+    )
+    assert api_key.grainy_permissions.count() == 1
+    assert api_key.is_scoped is True
+
+
+@pytest.mark.django_db
+def test_user_api_key_unscoped_by_default(user):
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=user)
+    assert api_key.is_scoped is False
+
+
+@pytest.mark.django_db
+def test_resolve_user_key_permission_id_net(user, org, network):
+    UserPermission.objects.create(
+        namespace=org.grainy_namespace, permission=PERM_CRUD, user=user
+    )
+    namespace, error = resolve_user_key_permission_id(user, f"net.{network.id}")
+    assert error is None
+    assert namespace == network.grainy_namespace
+
+
+@pytest.mark.django_db
+def test_resolve_user_key_permission_id_org(user, org):
+    UserPermission.objects.create(
+        namespace=org.grainy_namespace, permission=PERM_READ, user=user
+    )
+    namespace, error = resolve_user_key_permission_id(user, f"org.{org.id}")
+    assert error is None
+    assert namespace == org.grainy_namespace
+
+
+@pytest.mark.django_db
+def test_resolve_user_key_permission_id_denies_inaccessible_object(
+    user, org, network
+):
+    # user has no permissions on org/network at all
+    namespace, error = resolve_user_key_permission_id(user, f"net.{network.id}")
+    assert namespace is None
+    assert error is not None
+
+
+@pytest.mark.django_db
+def test_resolve_user_key_permission_id_invalid_format(user):
+    namespace, error = resolve_user_key_permission_id(user, "not-a-valid-id")
+    assert namespace is None
+    assert error is not None
+
+
+@pytest.mark.django_db
+def test_resolve_user_key_permission_id_unknown_object(user, org):
+    UserPermission.objects.create(
+        namespace=org.grainy_namespace, permission=PERM_CRUD, user=user
+    )
+    namespace, error = resolve_user_key_permission_id(user, "net.999999")
+    assert namespace is None
+    assert error is not None
+
+
+@pytest.mark.django_db
+def test_user_api_key_scoping_restricts_to_named_object(user, org, network):
+    """
+    A key scoped to a single network can read that network but
+    nothing else under the org, and only ever read (never write) -
+    even though the underlying user has full CRUD on the whole org.
+    """
+
+    UserPermission.objects.create(
+        namespace=org.grainy_namespace, permission=PERM_CRUD, user=user
+    )
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=user)
+
+    namespaces, errors = save_user_key_permissions(user, api_key, [f"net.{network.id}"])
+    assert errors == {}
+    assert namespaces == [network.grainy_namespace]
+
+    # can read the scoped network
+    assert check_permissions(api_key, network.grainy_namespace, "r")
+    # cannot write to it, despite the user having CRUD
+    assert check_permissions(api_key, network.grainy_namespace, "u") is False
+    # cannot see the org-wide namespace the user actually has CRUD on
+    assert check_permissions(api_key, org.grainy_namespace, "r") is False
+
+
+@pytest.mark.django_db
+def test_user_api_key_scoping_does_not_expand_access(user, org, network):
+    """
+    Scoping is a restriction, never a grant: if the user only has
+    read on the network, a scoped key pointed at it stays read-only
+    (this is also always true regardless, since scoping forces
+    PERM_READ - but the underlying intersection logic must not
+    accidentally grant more than the user has either).
+    """
+
+    UserPermission.objects.create(
+        namespace=network.grainy_namespace, permission=PERM_READ, user=user
+    )
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=user)
+
+    namespaces, errors = save_user_key_permissions(user, api_key, [f"net.{network.id}"])
+    assert errors == {}
+
+    assert check_permissions(api_key, network.grainy_namespace, "r")
+    assert check_permissions(api_key, network.grainy_namespace, "u") is False
+
+
+@pytest.mark.django_db
+def test_user_api_key_scoping_rejects_inaccessible_object(user, org, network):
+    """
+    Attempting to scope a key to an object the user can't themselves
+    read fails outright rather than silently scoping to nothing.
+    """
+
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=user)
+
+    namespaces, errors = save_user_key_permissions(user, api_key, [f"net.{network.id}"])
+    assert namespaces == []
+    assert f"net.{network.id}" in errors
+    assert api_key.grainy_permissions.count() == 0
+
+
+@pytest.mark.django_db
+def test_user_api_key_scoping_superuser_not_bypassed(admin_user, org, network):
+    """
+    Critical case: `Permissions.check` short-circuits to True for
+    superusers via `grant_all`. A scoped superuser key must still be
+    bound by its declared scope - the intersection logic must not
+    let grant_all leak through.
+    """
+
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=admin_user)
+
+    namespaces, errors = save_user_key_permissions(
+        admin_user, api_key, [f"net.{network.id}"]
+    )
+    assert errors == {}
+
+    # scoped network: readable
+    assert check_permissions(api_key, network.grainy_namespace, "r")
+    # anything outside the declared scope must NOT be reachable,
+    # despite the owning user being a superuser
+    assert check_permissions(api_key, org.grainy_namespace, "r") is False
+    assert check_permissions(api_key, "peeringdb.organization", "r") is False
+
+
+@pytest.mark.django_db
+def test_user_api_key_scoping_removal_restores_full_access(user, org, network):
+    UserPermission.objects.create(
+        namespace=org.grainy_namespace, permission=PERM_CRUD, user=user
+    )
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=user)
+
+    save_user_key_permissions(user, api_key, [f"net.{network.id}"])
+    assert api_key.is_scoped is True
+    assert check_permissions(api_key, org.grainy_namespace, "r") is False
+
+    # remove all scoping - key falls back to the user's full permissions
+    save_user_key_permissions(user, api_key, [])
+    api_key.refresh_from_db()
+    assert api_key.is_scoped is False
+    assert check_permissions(api_key, org.grainy_namespace, "u")
+
+
+@pytest.mark.django_db
+def test_user_key_permission_update_view(user, org, network):
+    UserPermission.objects.create(
+        namespace=org.grainy_namespace, permission=PERM_CRUD, user=user
+    )
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=user)
+
+    client = Client()
+    client.login(username="user", password="user")
+
+    response = client.post(
+        "/user_keys/permissions/update",
+        {"key_prefix": api_key.prefix, "entity": f"net.{network.id}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_scoped"] is True
+    assert f"net.{network.id}" in data["permissions"]
+
+
+@pytest.mark.django_db
+def test_user_key_permission_update_view_rejects_other_users_key(user, org, network):
+    other_user = User.objects.create_user(
+        "other", "other@localhost", first_name="other", last_name="other"
+    )
+    other_user.set_password("other")
+    other_user.save()
+
+    UserPermission.objects.create(
+        namespace=org.grainy_namespace, permission=PERM_CRUD, user=other_user
+    )
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=other_user)
+
+    client = Client()
+    client.login(username="user", password="user")
+
+    response = client.post(
+        "/user_keys/permissions/update",
+        {"key_prefix": api_key.prefix, "entity": f"net.{network.id}"},
+    )
+    # `user` doesn't own this key - lookup is scoped to request.user,
+    # so it should behave as "not found", not leak/modify another
+    # user's key
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_user_key_permission_remove_view(user, org, network):
+    UserPermission.objects.create(
+        namespace=org.grainy_namespace, permission=PERM_CRUD, user=user
+    )
+    api_key, key = UserAPIKey.objects.create_key(name="test key", user=user)
+    save_user_key_permissions(user, api_key, [f"net.{network.id}"])
+
+    client = Client()
+    client.login(username="user", password="user")
+
+    response = client.post(
+        "/user_keys/permissions/remove",
+        {"key_prefix": api_key.prefix, "entity": f"net.{network.id}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_scoped"] is False

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -793,7 +793,7 @@ def test_user_api_key_scoping_removal_restores_full_access(user, org, network):
 
     # remove all scoping - key falls back to the user's full permissions
     save_user_key_permissions(user, api_key, [])
-    api_key.refresh_from_db()
+    api_key = UserAPIKey.objects.get(prefix=api_key.prefix)
     assert api_key.is_scoped is False
     assert check_permissions(api_key, org.grainy_namespace, "u")
 


### PR DESCRIPTION
Added per-object and per-namespace read-scoping for UserAPIKey, mirroring the existing scoping pattern used for OrganizationAPIKey.

Previously, UserAPIKey was limited to a global readonly flag, meaning user keys either inherited the user's full permissions or were flattened to read-only across all namespaces. this adds UserAPIPermission and updates return_user_api_key_perms to allow tightly scoped user keys (e.g., restricting a bot or dashboard token to a single network object or specific organization).